### PR TITLE
Allow caller to override --logical-resource-id.

### DIFF
--- a/signalresource
+++ b/signalresource
@@ -2,7 +2,7 @@
 
 function handle() {
     set -eu
-    
+
     local res=${@:-""}
     if [ -z "$res" ]; then
         echo "signal-resource successful"
@@ -33,7 +33,7 @@ function run() {
             echo "... stopping signal retry after 180 seconds"
             exit 1
         fi
-        
+
         sleep $pause
         run $pause
     fi

--- a/signalresource
+++ b/signalresource
@@ -18,7 +18,8 @@ function handle() {
 }
 
 function signal() {
-    aws cloudformation signal-resource --stack-name $STACK_NAME --logical-resource-id AutoScalingGroup --status SUCCESS --unique-id $INSTANCE_ID 2>&1
+    local logicalid=${AUTOSCALING_GROUP_NAME:-"AutoScalingGroup"}
+    aws cloudformation signal-resource --stack-name $STACK_NAME --logical-resource-id $logicalid --status SUCCESS --unique-id $INSTANCE_ID 2>&1
 }
 
 count=0

--- a/test
+++ b/test
@@ -61,11 +61,69 @@ fi
 echo "# run"
 
 function aws() {
+    stack=$4
+    resource=$6
+    instance=$8
+
+    if [ "$stack" != "xxx" ]; then
+        echo "unexpected stack $stack"
+        exit 1
+    fi
+
+    if [ "$resource" != "AutoScalingGroup" ]; then
+        echo "unexpected resource $resource`"
+        exit 1
+    fi
+
+    if [ "$instance" != "xxx" ]; then
+        echo "unexpected instance $instance`"
+        exit 1
+    fi
+
     exit 0
 }
 
 STACK_NAME=xxx
 INSTANCE_ID=xxx
+got=$(run)
+expected="signal-resource successful"
+if [ "$got" = "$expected" ]; then
+    echo "ok - [run] successful signal-resource"
+else
+    echo "not ok - [run] successful signal-resource"
+    echo ""
+    echo "  expected: ${expected}"
+    echo "  got: ${got}"
+    echo ""
+    code=1
+fi
+
+function aws() {
+    stack=$4
+    resource=$6
+    instance=$8
+
+    if [ "$stack" != "xxx" ]; then
+        echo "unexpected stack $stack"
+        exit 1
+    fi
+
+    if [ "$resource" != "xxx" ]; then
+        echo "unexpected resource $resource`"
+        exit 1
+    fi
+
+    if [ "$instance" != "xxx" ]; then
+        echo "unexpected instance $instance`"
+        exit 1
+    fi
+
+    exit 0
+}
+
+STACK_NAME=xxx
+INSTANCE_ID=xxx
+AUTOSCALING_GROUP_NAME=xxx
 got=$(run)
 expected="signal-resource successful"
 if [ "$got" = "$expected" ]; then

--- a/test
+++ b/test
@@ -4,7 +4,7 @@ source $(dirname $0)/signalresource
 set -eu
 code=0
 
-echo "# handle" 
+echo "# handle"
 
 got=$(handle "")
 expected="signal-resource successful"
@@ -58,7 +58,7 @@ else
     code=1
 fi
 
-echo "# run" 
+echo "# run"
 
 function aws() {
     exit 0
@@ -85,7 +85,7 @@ function aws() {
 
 STACK_NAME=xxx
 INSTANCE_ID=xxx
-got=$(run) 
+got=$(run)
 expected="disregarding this is a ValidationError from signal-resource"
 if [ "$got" = "$expected" ]; then
     echo "ok - [run] disregard ValidationError"


### PR DESCRIPTION
Allow caller to override --logical-resource-id.

Set the AUTOSCALING_GROUP_NAME environment variable to override what value is
used for the --logical-resource-id argument. Defaults to `AutoScalingGroup`.

Fixes https://github.com/mapbox/aws-cfn-signalresource/issues/3
