### PR TITLE
Update run url in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Wrapper around aws cli's `cloudformation signal-resource` to handle retries & er
 ### run from S3
 
 ```
-$ curl -s https://s3.amazonaws.com/mapbox/apps/aws-cfn-signalresource/v0.0.1 | bash
+$ curl -s https://s3.amazonaws.com/mapbox/apps/aws-cfn-signalresource/v0.2.0 | bash
 ```
 
 ### Install via NPM


### PR DESCRIPTION
@emilymcafee this just wasted most of my afternoon -- I had copied the run URL from the readme file, but was trying to set `$AUTOSCALING_GROUP_NAME`, which was not a thing until v0.1.0.

`>_<`
